### PR TITLE
Profile storage fix readme

### DIFF
--- a/profile-storage/app/roles/api.lua
+++ b/profile-storage/app/roles/api.lua
@@ -1,4 +1,3 @@
-local vshard = require('vshard')
 local cartridge = require('cartridge')
 local errors = require('errors')
 local log = require('log')
@@ -56,11 +55,13 @@ end
 local function http_profile_add(req)
     local profile = req:json()
 
-    local bucket_id = vshard.router.bucket_id(profile.profile_id)
+    local router = cartridge.service_get('vshard-router').get()
+    local bucket_id = router:bucket_id(profile.profile_id)
     profile.bucket_id = bucket_id
 
     local resp, error = err_vshard_router:pcall(
-        vshard.router.call,
+        router.call,
+        router,
         bucket_id,
         'write',
         'profile_add',
@@ -83,10 +84,12 @@ local function http_profile_update(req)
     local changes = data.changes
     local password = data.password
 
-    local bucket_id = vshard.router.bucket_id(profile_id)
+    local router = cartridge.service_get('vshard-router').get()
+    local bucket_id = router:bucket_id(profile_id)
     
     local resp, error = err_vshard_router:pcall(
-        vshard.router.call,
+        router.call,
+        router,
         bucket_id,
         'read',
         'profile_update',
@@ -106,10 +109,12 @@ end
 local function http_profile_get(req)
     local profile_id = tonumber(req:stash('profile_id'))
     local password = req:json().password
-    local bucket_id = vshard.router.bucket_id(profile_id)
+    local router = cartridge.service_get('vshard-router').get()
+    local bucket_id = router:bucket_id(profile_id)
 
     local resp, error = err_vshard_router:pcall(
-        vshard.router.call,
+        router.call,
+        router,
         bucket_id,
         'read',
         'profile_get',
@@ -129,10 +134,12 @@ end
 local function http_profile_delete(req)
     local profile_id = tonumber(req:stash('profile_id'))
     local password = req:json().password
-    local bucket_id = vshard.router.bucket_id(profile_id)
+    local router = cartridge.service_get('vshard-router').get()
+    local bucket_id = router:bucket_id(profile_id)
 
     local resp, error = err_vshard_router:pcall(
-        vshard.router.call,
+        router.call,
+        router,
         bucket_id,
         'write',
         'profile_delete',
@@ -150,8 +157,6 @@ local function http_profile_delete(req)
 end
 
 local function init(opts)
-    rawset(_G, 'vshard', vshard)
-
     if opts.is_master then
         box.schema.user.grant('guest',
             'read,write',

--- a/profile-storage/app/roles/storage.lua
+++ b/profile-storage/app/roles/storage.lua
@@ -150,11 +150,6 @@ local function init(opts)
         box.schema.func.create('profile_get', {if_not_exists = true})
         box.schema.func.create('profile_update', {if_not_exists = true})
         box.schema.func.create('profile_delete', {if_not_exists = true})
-
-        box.schema.role.grant('public', 'execute', 'function', 'profile_add', {if_not_exists = true})
-        box.schema.role.grant('public', 'execute', 'function', 'profile_get', {if_not_exists = true})
-        box.schema.role.grant('public', 'execute', 'function', 'profile_update', {if_not_exists = true})
-        box.schema.role.grant('public', 'execute', 'function', 'profile_delete', {if_not_exists = true})
     end
 
     rawset(_G, 'profile_add', profile_add)

--- a/profile-storage/test/helper/integration.lua
+++ b/profile-storage/test/helper/integration.lua
@@ -36,10 +36,7 @@ helper.assert_http_json_request = function (method, path, body, expected)
         raise = false
     })
 
-    if expected.body then
-        t.assert_equals(response.json, expected.body)
-    end
-
+    t.assert_equals(response.json, expected.body)
     t.assert_equals(response.status, expected.status)
 
     return response

--- a/profile-storage/test/integration/api_test.lua
+++ b/profile-storage/test/integration/api_test.lua
@@ -30,7 +30,7 @@ end
 g.test_on_post_ok = function ()
     local user_with_password = deepcopy(test_profile)
     user_with_password.password = user_password
-    helper.assert_http_json_request('post', '/profile', user_with_password, {status=201})
+    helper.assert_http_json_request('post', '/profile', user_with_password, {body = {info = "Successfully created"}, status=201})
 end
 
 g.test_on_post_conflict = function()


### PR DESCRIPTION
1. Убрал `box.schema.role.grant(...)` для функций роли storage
2. Убрал `rawset(_G, vshard, vshard)` из init роли api
3. Заменил вызов статического `vshard.router` на `cartridge.service_get('vshard-router')`
4. Дополнил описание `err_vshard_router` в README в примечании про `pcall`